### PR TITLE
Set upper bounds of dependencies

### DIFF
--- a/ch.res_ear.samthiriot.knime.shapefilesaswkt.feature/feature.xml
+++ b/ch.res_ear.samthiriot.knime.shapefilesaswkt.feature/feature.xml
@@ -22,9 +22,8 @@ D-76131 Karlsruhe
 Germany
    </copyright>
 
-   <license url="https://www.gnu.org/licenses/gpl.txt">
-      GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+   <license url="http://www.gnu.org/licenses/gpl-3.0.html">
+GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. &lt;https://fsf.org/&gt;
  Everyone is permitted to copy and distribute verbatim copies

--- a/ch.res_ear.samthiriot.knime.shapefilesaswkt/META-INF/MANIFEST.MF
+++ b/ch.res_ear.samthiriot.knime.shapefilesaswkt/META-INF/MANIFEST.MF
@@ -145,12 +145,12 @@ Bundle-ClassPath: readshapefileaskml.jar,
  lib/xpp3_min-1.1.4c.jar
 Bundle-Activator: ch.res_ear.samthiriot.knime.shapefilesaswkt.ShapefileAsWKTNodePlugin
 Bundle-Vendor: EIFER (European Institute for Energy Research)
-Require-Bundle: org.knime.workbench.core,
- org.knime.base,
+Require-Bundle: org.knime.workbench.core;bundle-version="[3.7.0,5.0.0)",
+ org.knime.base;bundle-version="[3.7.0,5.0.0)",
  org.eclipse.xsd;bundle-version="2.13.0",
- org.knime.product;bundle-version="3.7.2",
- org.knime.workbench;bundle-version="3.7.0",
- org.knime.testing
+ org.knime.product;bundle-version="[3.7.0,5.0.0)",
+ org.knime.workbench;bundle-version="[3.7.0,5.0.0)",
+ org.knime.testing;bundle-version="[3.7.0,5.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: .,
  au.com.objectix.jgridshift,


### PR DESCRIPTION
Upper bounds are required to ensure plugins are not installed into a version of KNIME AP that does not support them. 